### PR TITLE
Restructure the BoTorch interface

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,8 @@ exclude =
     build,
     dist,
     docs/source/conf.py
-    examples/benchmark.py,
+    examples/prepare_bluesky.py,
+    examples/prepare_tes_shadow.py,
     bloptools/tests/test_boa.py,
     versioneer.py,
 max-line-length = 115

--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,7 @@ exclude =
     build,
     dist,
     docs/source/conf.py
+    examples/benchmark.py,
     examples/prepare_bluesky.py,
     examples/prepare_tes_shadow.py,
     bloptools/tests/test_boa.py,

--- a/bloptools/bo/__init__.py
+++ b/bloptools/bo/__init__.py
@@ -84,7 +84,6 @@ class BayesianOptimizationAgent:
         self.inv_params_trans_fun = lambda x: x * self.bounds.ptp(axis=1) + self.bounds.min(axis=1)
 
         # for actual prediction and optimization
-
         self.params = np.empty((0, self.n_dof))
         self.data = pd.DataFrame()
 

--- a/bloptools/bo/__init__.py
+++ b/bloptools/bo/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp  # noqa F401
 import h5py
@@ -203,12 +205,14 @@ class BayesianOptimizationAgent:
         if verbose:
             print(f"sampling {ordered_params}")
 
-        # try:
-        uid = yield from bp.list_scan(
-            self.dets, *[_ for items in zip(self.dofs, np.atleast_2d(ordered_params).T) for _ in items]
-        )
-        _table = self.db[uid].table(fill=True)
-        _table.loc[:, "uid"] = uid
+        try:
+            uid = yield from bp.list_scan(
+                self.dets, *[_ for items in zip(self.dofs, np.atleast_2d(ordered_params).T) for _ in items]
+            )
+            _table = self.db[uid].table(fill=True)
+            _table.loc[:, "uid"] = uid
+        except Exception as err:
+            logging.warning(repr(err))
 
         for i, entry in _table.iterrows():
             keys, vals = self.experiment.parse_entry(entry)

--- a/bloptools/bo/__init__.py
+++ b/bloptools/bo/__init__.py
@@ -268,23 +268,14 @@ class BayesianOptimizationAgent:
                 if not all(cost > 0):
                     raise ValueError("Some estimated acquisition times are non-positive.")
 
-            if strategy.lower() == "ei":  # greedy expected reward maximization
+            if strategy.lower() == "ei":  # maximize the expected improvement
                 objective = acquisition.expected_improvement(evaluator, classifier, TEST_X).sum(axis=1)
 
-            if strategy.lower() == "explore":  # greedy expected reward maximization
-                objective = -self._negative_expected_variance(evaluator, classifier, TEST_X).sum(axis=1)
+            if strategy.lower() == "max_entropy":  # maximize the total entropy
+                objective = (evaluator.normalized_entropy(TEST_X) + classifier.entropy(TEST_X)).sum(axis=1)
 
-            if strategy.lower() == "egibbon":
+            if strategy.lower() == "egibbon":  # maximize the expected GIBBON
                 objective = acquisition.expected_gibbon(evaluator, classifier, TEST_X).sum(axis=1)
-
-            # if strategy.lower() == "ip":
-            #     objective = -self._negative_improvement_probability(evaluator, classifier, evaluator.X, TEST_X)
-
-            # if strategy.lower() == "a-optimal":
-            #     objective = -self._negative_A_optimality(TEST_X)
-
-            # if strategy.lower() == "d-optimal":
-            #     objective = -self._negative_D_optimality(TEST_X)
 
             return TEST_X[np.argmax(objective / cost)]
 

--- a/bloptools/bo/acquisition.py
+++ b/bloptools/bo/acquisition.py
@@ -1,0 +1,47 @@
+import numpy as np
+import scipy as sp
+import torch
+from botorch.acquisition.analytic import LogExpectedImprovement
+from botorch.acquisition.max_value_entropy_search import qLowerBoundMaxValueEntropy
+
+# these return the values of the acquisition objectives
+
+
+def expected_improvement(evaluator, classifier, X):
+    torch_X = torch.as_tensor(X.reshape(-1, X.shape[-1]))
+
+    ei = np.exp(
+        LogExpectedImprovement(evaluator.model, best_f=evaluator.Y.max())(torch_X.unsqueeze(1)).detach().numpy()
+    )
+    p_good = classifier.p(torch_X)
+
+    return (ei * p_good).reshape(X.shape[:-1])
+
+
+def expected_gibbon(evaluator, classifier, X, n_candidates=1024):
+    torch_X = torch.as_tensor(X.reshape(-1, X.shape[-1]))
+
+    sampler = sp.stats.qmc.Halton(d=evaluator.X.shape[-1], scramble=True)
+    candidate_set = torch.as_tensor(sampler.random(n=n_candidates)).double()
+
+    gibbon = qLowerBoundMaxValueEntropy(evaluator.model, candidate_set)(torch_X.unsqueeze(1)).detach().numpy()
+    p_good = classifier.p(torch_X)
+
+    return (gibbon * p_good).reshape(X.shape[:-1])
+
+
+# these return params that maximize the objective
+
+
+def MaxExpectedImprovement(evaluator, classifier, n_test=1024):
+    sampler = sp.stats.qmc.Halton(d=evaluator.X.shape[-1], scramble=True)
+    test_X = torch.as_tensor(sampler.random(n=n_test)).double()
+
+    return test_X(expected_improvement(evaluator, classifier, test_X).argmax())
+
+
+def MaxExpectedGIBBON(evaluator, classifier, n_test=1024):
+    sampler = sp.stats.qmc.Halton(d=evaluator.X.shape[-1], scramble=True)
+    test_X = torch.as_tensor(sampler.random(n=n_test)).double()
+
+    return test_X(expected_gibbon(evaluator, classifier, test_X).argmax())

--- a/bloptools/bo/acquisition.py
+++ b/bloptools/bo/acquisition.py
@@ -8,6 +8,10 @@ from botorch.acquisition.max_value_entropy_search import qLowerBoundMaxValueEntr
 
 
 def expected_improvement(evaluator, classifier, X):
+    """
+    Given a botorch fitness model "evaluator" and a botorch validation model "classifier", compute the
+    expected improvement at parameters X.
+    """
     torch_X = torch.as_tensor(X.reshape(-1, X.shape[-1]))
 
     ei = np.exp(
@@ -19,6 +23,10 @@ def expected_improvement(evaluator, classifier, X):
 
 
 def expected_gibbon(evaluator, classifier, X, n_candidates=1024):
+    """
+    Given a botorch fitness model "evaluator" and a botorch validation model "classifier", compute the
+    expected GIBBON at parameters X (https://www.jmlr.org/papers/volume22/21-0120/21-0120.pdf)
+    """
     torch_X = torch.as_tensor(X.reshape(-1, X.shape[-1]))
 
     sampler = sp.stats.qmc.Halton(d=evaluator.X.shape[-1], scramble=True)
@@ -33,14 +41,20 @@ def expected_gibbon(evaluator, classifier, X, n_candidates=1024):
 # these return params that maximize the objective
 
 
-def MaxExpectedImprovement(evaluator, classifier, n_test=1024):
+def max_expected_improvement(evaluator, classifier, n_test=1024):
+    """
+    Compute the expected improvement over quasi-random sampled parameters, and return the location of the maximum.
+    """
     sampler = sp.stats.qmc.Halton(d=evaluator.X.shape[-1], scramble=True)
     test_X = torch.as_tensor(sampler.random(n=n_test)).double()
 
     return test_X(expected_improvement(evaluator, classifier, test_X).argmax())
 
 
-def MaxExpectedGIBBON(evaluator, classifier, n_test=1024):
+def max_expected_gibbon(evaluator, classifier, n_test=1024):
+    """
+    Compute the expected GIBBON over quasi-random sampled parameters, and return the location of the maximum.
+    """
     sampler = sp.stats.qmc.Halton(d=evaluator.X.shape[-1], scramble=True)
     test_X = torch.as_tensor(sampler.random(n=n_test)).double()
 

--- a/bloptools/bo/models.py
+++ b/bloptools/bo/models.py
@@ -42,15 +42,55 @@ class BoTorchClassifier(gpytorch.models.ExactGP, botorch.models.gpytorch.GPyTorc
         return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
 
 
-class GPR:
+class BoTorchModelWrapper:
+    def __init__(self, bounds, MIN_SNR=1e-2):
+        self.model = None
+        self.bounds = bounds
+        self.MIN_SNR = MIN_SNR
+
+        self.prepare_inputs = lambda inputs: torch.tensor(
+            (inputs - self.bounds.min(axis=1)) / self.bounds.ptp(axis=1)
+        ).double()
+        self.unprepare_inputs = lambda inputs: inputs.detach().numpy() * self.bounds.ptp(axis=1) + self.bounds.min(
+            axis=1
+        )
+
+    def tell(self, X, Y):
+        self.model.set_train_data(
+            torch.cat([self.train_inputs, self.prepare_inputs(X)]),
+            torch.cat([self.train_targets, self.prepare_targets(Y)]),
+            strict=False,
+        )
+
+    def train(self, **kwargs):
+        botorch.optim.fit.fit_gpytorch_mll_torch(self.mll, optimizer=torch.optim.Adam, **kwargs)
+
+    @property
+    def train_inputs(self):
+        return self.prepare_inputs(self.X)
+
+    @property
+    def train_targets(self):
+        return self.prepare_targets(self.Y)
+
+    @property
+    def n(self):
+        return self.X.shape[0]
+
+    @property
+    def n_dof(self):
+        return self.X.shape[-1]
+
+    @property
+    def n_tasks(self):
+        return self.Y.shape[-1]
+
+
+class GPR(BoTorchModelWrapper):
 
     """
     A Gaussian process regressor, with learning methods.
     """
-
-    def __init__(self, MIN_SNR=1e-2):
-        self.model = None
-        self.MIN_SNR = MIN_SNR
 
     def set_data(self, X, Y):
         """
@@ -66,12 +106,24 @@ class GPR:
         # prepare Gaussian process ingredients for the regressor and classifier
         # use only regressable points for the regressor
 
+        self.X, self.Y = X, Y
+
+        self.target_means = Y.mean(axis=0)
+        self.target_scales = Y.std(axis=0)
+
+        self.prepare_targets = lambda targets: torch.tensor(
+            (targets - self.target_means[None]) / self.target_scales[None]
+        ).double()
+        self.unprepare_targets = (
+            lambda targets: targets.detach().numpy() * self.target_scales[None] + self.target_means[None]
+        )
+
         self.num_tasks = Y.shape[-1]
 
-        self.noise_upper_bound = np.square((1 if not Y.shape[0] > 1 else Y.std(axis=0)) / self.MIN_SNR)
+        self.noise_upper_bound = np.square(1 / self.MIN_SNR)
 
         likelihood_noise_constraint = gpytorch.constraints.Interval(
-            0, torch.as_tensor(self.noise_upper_bound).double()
+            0, torch.tensor(self.noise_upper_bound).double()
         )
 
         likelihood = MultitaskGaussianLikelihood(
@@ -80,52 +132,18 @@ class GPR:
         ).double()
 
         self.model = BoTorchMultiTaskGP(
-            train_X=torch.as_tensor(X).double(),
-            train_Y=torch.as_tensor(Y).double(),
+            train_X=self.train_inputs,
+            train_Y=self.train_targets,
             likelihood=likelihood,
         ).double()
 
         self.mll = gpytorch.mlls.ExactMarginalLogLikelihood(self.model.likelihood, self.model)
 
-    @property
-    def torch_inputs(self):
-        return self.model.train_inputs[0]
-
-    @property
-    def torch_targets(self):
-        return self.model.train_targets
-
-    @property
-    def X(self):
-        return self.torch_inputs.detach().numpy().astype(float)
-
-    @property
-    def Y(self):
-        return self.torch_targets.detach().numpy().astype(float)
-
-    @property
-    def n(self):
-        return self.Y.size
-
-    @property
-    def n_dof(self):
-        return self.X.shape[-1]
-
-    def tell(self, X, Y):
-        self.model.set_train_data(
-            torch.cat([self.torch_inputs, torch.as_tensor(np.atleast_2d(X))]).double(),
-            torch.cat([self.torch_targets, torch.as_tensor(np.atleast_2d(Y))]).double(),
-            strict=False,
-        )
-
-    def train(self, maxiter=100, lr=1e-2):
-        botorch.optim.fit.fit_gpytorch_mll_torch(self.mll, optimizer=torch.optim.Adam, step_limit=256)
-
     def copy(self):
         if self.model is None:
             raise RuntimeError("You cannot copy a model with no data.")
 
-        dummy = GPR()
+        dummy = GPR(bounds=self.bounds, MIN_SNR=self.MIN_SNR)
         dummy.set_data(self.X, self.Y)
         dummy.model.load_state_dict(self.model.state_dict())
 
@@ -133,13 +151,13 @@ class GPR:
 
     def mean(self, X):
         *input_shape, _ = X.shape
-        x = torch.as_tensor(X.reshape(-1, self.n_dof)).double()
-        return self.model.posterior(x).mean.detach().numpy().reshape(input_shape)
+        x = self.prepare_inputs(X).reshape(-1, self.n_dof)
+        return self.unprepare_targets(self.model.posterior(x).mean).reshape(input_shape)
 
     def sigma(self, X):
         *input_shape, _ = X.shape
-        x = torch.as_tensor(X.reshape(-1, self.n_dof)).double()
-        return self.model.posterior(x).stddev.detach().numpy().reshape(input_shape)
+        x = self.prepare_inputs(X).reshape(-1, self.n_dof)
+        return self.target_scales * self.model.posterior(x).stddev.detach().numpy().reshape(input_shape)
 
     @property
     def scale(self):
@@ -202,13 +220,10 @@ class GPR:
         return FIM_stack
 
 
-class GPC:
+class GPC(BoTorchModelWrapper):
     """
     A Gaussian process classifier, with learning methods.
     """
-
-    def __init__(self):
-        self.model = None
 
     def set_data(self, X, c):
         """
@@ -220,53 +235,31 @@ class GPC:
         Passed parameters must be between [-1, 1] in every dimension. Passed values must be integer labels.
         """
 
+        self.X, self.c = X, c
+
+        self.prepare_targets = lambda targets: torch.tensor(targets).int()
+        self.unprepare_targets = lambda targets: targets.detach().numpy().astype(int)
+
         dirichlet_likelihood = gpytorch.likelihoods.DirichletClassificationLikelihood(
             torch.as_tensor(c).int(), learn_additional_noise=True
         ).double()
 
         self.model = BoTorchClassifier(
-            torch.as_tensor(X).double(),
+            self.train_inputs,
             dirichlet_likelihood.transformed_targets,
             dirichlet_likelihood,
         ).double()
 
         self.mll = gpytorch.mlls.ExactMarginalLogLikelihood(self.model.likelihood, self.model)
 
-    @property
-    def torch_inputs(self):
-        return self.model.train_inputs[0]
-
-    @property
-    def torch_targets(self):
-        return self.model.train_targets
-
-    @property
-    def X(self):
-        return self.torch_inputs.detach().numpy().astype(float)
-
-    @property
-    def c(self):
-        return self.torch_targets.detach().numpy().argmax(axis=0)
-
-    @property
-    def n(self):
-        return self.c.size
-
-    @property
-    def n_dof(self):
-        return self.X.shape[-1]
-
     def tell(self, X, c):
         self.set_data(np.r_[self.X, np.atleast_2d(X)], np.r_[self.c, np.atleast_1d(c)])
-
-    def train(self, maxiter=100, lr=1e-2):
-        botorch.optim.fit.fit_gpytorch_mll_torch(self.mll, optimizer=torch.optim.Adam, step_limit=256)
 
     def copy(self):
         if self.model is None:
             raise RuntimeError("You cannot copy a model with no data.")
 
-        dummy = GPC()
+        dummy = GPC(bounds=self.bounds, MIN_SNR=self.MIN_SNR)
         dummy.set_data(self.X, self.c)
         dummy.model.load_state_dict(self.model.state_dict())
 
@@ -274,15 +267,11 @@ class GPC:
 
     def p(self, X, n_samples=256):
         *input_shape, _ = X.shape
-
-        x = torch.as_tensor(X.reshape(-1, self.n_dof)).double()
-
+        x = self.prepare_inputs(X).reshape(-1, self.n_dof)
         samples = self.model.posterior(x).sample(torch.Size((n_samples,))).exp()
-
         return (samples / samples.sum(-3, keepdim=True)).mean(0)[1].reshape(input_shape).detach().numpy()
 
     def entropy(self, X, n_samples=256):
         p = self.p(X, n_samples)
         q = 1 - p
-
         return -p * np.log(p) - q * np.log(q)

--- a/bloptools/experiments/shadow/tes.py
+++ b/bloptools/experiments/shadow/tes.py
@@ -1,6 +1,7 @@
+import bluesky.plan_stubs as bps
 import numpy as np
 
-from ... import utils
+from .... import utils
 
 DEPENDENT_COMPONENTS = ["w9"]
 
@@ -16,8 +17,8 @@ MIN_SEPARABILITY = 0.1  # the minimal variance proportion of the first SVD mode 
 MIN_SNR = 1e1
 
 
-def initialize():
-    yield from iter([])  # do nothing
+def initialize(self):
+    yield from bps.null()  # do nothing
 
 
 def parse_entry(entry):

--- a/bloptools/experiments/shadow/tes.py
+++ b/bloptools/experiments/shadow/tes.py
@@ -1,7 +1,7 @@
 import bluesky.plan_stubs as bps
 import numpy as np
 
-from .... import utils
+from ... import utils
 
 DEPENDENT_COMPONENTS = ["w9"]
 
@@ -17,7 +17,7 @@ MIN_SEPARABILITY = 0.1  # the minimal variance proportion of the first SVD mode 
 MIN_SNR = 1e1
 
 
-def initialize(self):
+def initialize():
     yield from bps.null()  # do nothing
 
 

--- a/bloptools/experiments/tests/__init__.py
+++ b/bloptools/experiments/tests/__init__.py
@@ -8,7 +8,7 @@ def get_dofs(n=2):
 
 
 class BaseOptimizationTest:
-    MIN_SNR = 1e2
+    MIN_SNR = 1e3
 
     n_dof = 2
     dofs = get_dofs(n=2)
@@ -64,7 +64,7 @@ class Himmelblau(BaseOptimizationTest):
 
 class Rosenbrock(BaseOptimizationTest):
     """
-    Ackley's function in $n$ dimensions (https://en.wikipedia.org/wiki/Ackley_function)
+    Rosenbrock function in $n$ dimensions (hhttps://en.wikipedia.org/wiki/Rosenbrock_function)
     """
 
     def __init__(self, n_dof=2):
@@ -78,9 +78,21 @@ class Rosenbrock(BaseOptimizationTest):
         return -np.log((100 * (X[..., 1:] - X[..., :-1] ** 2) ** 2 + (1 - X[..., :-1]) ** 2).sum(axis=-1))
 
 
+class ConstrainedRosenbrock(Rosenbrock):
+    """
+    Rosenbrock function in $n$ dimensions (hhttps://en.wikipedia.org/wiki/Rosenbrock_function)
+    """
+
+    @staticmethod
+    def fitness_func(X):
+        if (X**2).sum(axis=-1) > len(X):
+            return np.nan
+        return -np.log((100 * (X[..., 1:] - X[..., :-1] ** 2) ** 2 + (1 - X[..., :-1]) ** 2).sum(axis=-1))
+
+
 class StyblinskiTang(BaseOptimizationTest):
     """
-    Ackley's function in $n$ dimensions (https://en.wikipedia.org/wiki/Ackley_function)
+    Styblinski-Tang function in $n$ dimensions (https://en.wikipedia.org/wiki/Test_functions_for_optimization)
     """
 
     def __init__(self, n_dof=2):

--- a/bloptools/experiments/tests/__init__.py
+++ b/bloptools/experiments/tests/__init__.py
@@ -7,53 +7,88 @@ def get_dofs(n=2):
     return [Signal(name=f"x{i+1}", value=0) for i in range(n)]
 
 
-class Ackley:
+class BaseOptimizationTest:
+    MIN_SNR = 1e2
+
+    n_dof = 2
+    dofs = get_dofs(n=2)
+    bounds = np.array([[-5.0, +5.0], [-5.0, +5.0]])
+
+    DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(2)]
+
+    def initialize(self):
+        yield from bps.null()  # do nothing
+
+    def parse_entry(self, entry):
+        X = np.array([getattr(entry, cpt) for cpt in self.DEPENDENT_COMPONENTS])
+        fitness = self.fitness_func(X)
+        return ("fitness"), (fitness)
+
+
+class Ackley(BaseOptimizationTest):
     """
     Ackley's function in $n$ dimensions (https://en.wikipedia.org/wiki/Ackley_function)
     """
 
-    MIN_SNR = 1e1
-
     def __init__(self, n_dof=2):
         self.n_dof = n_dof
-        self.dofs = [getattr(self.dofs_256, f"x{i+1}") for i in range(self.n_dof)]
-        self.bounds = np.array([[0.0, 1.0] for i in range(self.n_dof)])
-
+        self.dofs = get_dofs(n=n_dof)
+        self.bounds = np.array([[-5.0, +5.0] for i in range(self.n_dof)])
         self.DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(self.n_dof)]
 
-    def initialize(self):
-        yield from bps.null()  # do nothing
-
-    def parse_entry(self, entry):
-        # get the ingredient from our dependent variables
-        x = 4 * (np.c_[[getattr(entry, f"dofs_x{i+1}") for i in range(self.n_dof)]] - 0.5)
-
-        fitness = np.exp(-0.2 * np.sqrt(0.5 * np.sum(x**2))) + 5e-2 * np.exp(0.5 * np.sum(np.cos(2 * np.pi * x)))
-
-        return ("fitness"), (fitness)
+    @staticmethod
+    def fitness_func(X):
+        return (
+            20 * np.exp(-0.2 * np.sqrt(0.5 * np.sum(X**2)))
+            + 5e-2 * np.exp(0.5 * np.sum(np.cos(2 * np.pi * X)))
+            - 20
+            - np.e
+        )
 
 
-class Himmelblau:
+class Himmelblau(BaseOptimizationTest):
     """
     Himmelblau's function (https://en.wikipedia.org/wiki/Himmelblau%27s_function)
     """
 
-    MIN_SNR = 1e1
+    n_dof = 2
+    dofs = get_dofs(n=2)
+    bounds = np.array([[-5.0, +5.0], [-5.0, +5.0]])
 
-    def __init__(self):
-        self.n_dof = 2
-        self.dofs = get_dofs(n=2)
-        self.bounds = np.array([[0.0, 1.0] for i in range(self.n_dof)])
+    DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(2)]
 
+    @staticmethod
+    def fitness_func(X):
+        return -((X[0] ** 2 + X[1] - 11) ** 2 + (X[0] + X[1] ** 2 - 7) ** 2)
+
+
+class Rosenbrock(BaseOptimizationTest):
+    """
+    Ackley's function in $n$ dimensions (https://en.wikipedia.org/wiki/Ackley_function)
+    """
+
+    def __init__(self, n_dof=2):
+        self.n_dof = n_dof
+        self.dofs = get_dofs(n=n_dof)
+        self.bounds = np.array([[-2.0, +2.0] for i in range(self.n_dof)])
         self.DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(self.n_dof)]
 
-    def initialize(self):
-        yield from bps.null()  # do nothing
+    @staticmethod
+    def fitness_func(X):
+        return -np.log((100 * (X[..., 1:] - X[..., :-1] ** 2) ** 2 + (1 - X[..., :-1]) ** 2).sum(axis=-1))
 
-    def parse_entry(self, entry):
-        # get the ingredient from our dependent variables
-        x = 10 * (np.array([getattr(entry, f"x{i+1}") for i in range(self.n_dof)]) - 0.5)
 
-        fitness = -1e-2 * ((x[0] ** 2 + x[1] - 11) ** 2 + (x[0] + x[1] ** 2 - 7) ** 2)
+class StyblinskiTang(BaseOptimizationTest):
+    """
+    Ackley's function in $n$ dimensions (https://en.wikipedia.org/wiki/Ackley_function)
+    """
 
-        return ("fitness"), (fitness)
+    def __init__(self, n_dof=2):
+        self.n_dof = n_dof
+        self.dofs = get_dofs(n=n_dof)
+        self.bounds = np.array([[-5.0, +5.0] for i in range(self.n_dof)])
+        self.DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(self.n_dof)]
+
+    @staticmethod
+    def fitness_func(X):
+        return -(X**4 - 16 * X**2 + 5 * X).sum(axis=-1)

--- a/bloptools/experiments/tests/__init__.py
+++ b/bloptools/experiments/tests/__init__.py
@@ -1,0 +1,56 @@
+import numpy as np
+from ophyd import Component as Cpt  # noqa F401
+from ophyd import Device, Signal  # noqa F401
+
+
+class DOF256s(Device):
+    for i in range(256):
+        exec(f"x{i+1} = Cpt(Signal, value=0)")
+
+
+class Ackley:
+    dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
+
+    MIN_SNR = 1e1
+
+    def __init__(self, n_dof=2):
+        self.n_dof = n_dof
+        self.dofs = [getattr(self.dofs_256, f"x{i+1}") for i in range(self.n_dof)]
+        self.bounds = np.array([[0.0, 1.0] for i in range(self.n_dof)])
+
+        self.DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(self.n_dof)]
+
+    def initialize(self):
+        yield from iter([])  # do nothing
+
+    def parse_entry(self, entry):
+        # get the ingredient from our dependent variables
+        x = 4 * (np.c_[[getattr(entry, f"dofs_x{i+1}") for i in range(self.n_dof)]] - 0.5)
+
+        fitness = np.exp(-0.2 * np.sqrt(0.5 * np.sum(x**2))) + 5e-2 * np.exp(0.5 * np.sum(np.cos(2 * np.pi * x)))
+
+        return ("fitness"), (fitness)
+
+
+class Himmelblau:
+    dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
+
+    MIN_SNR = 1e1
+
+    def __init__(self):
+        self.n_dof = 2
+        self.dofs = [getattr(self.dofs_256, f"x{i+1}") for i in range(2)]
+        self.bounds = np.array([[0.0, 1.0] for i in range(self.n_dof)])
+
+        self.DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(self.n_dof)]
+
+    def initialize(self):
+        yield from iter([])  # do nothing
+
+    def parse_entry(self, entry):
+        # get the ingredient from our dependent variables
+        x = 10 * (np.array([getattr(entry, f"dofs_x{i+1}") for i in range(self.n_dof)]) - 0.5)
+
+        fitness = -1e-2 * ((x[0] ** 2 + x[1] - 11) ** 2 + (x[0] + x[1] ** 2 - 7) ** 2)
+
+        return ("fitness"), (fitness)

--- a/bloptools/experiments/tests/__init__.py
+++ b/bloptools/experiments/tests/__init__.py
@@ -1,15 +1,18 @@
+import bluesky.plan_stubs as bps
 import numpy as np
-from ophyd import Component as Cpt  # noqa F401
-from ophyd import Device, Signal  # noqa F401
+from ophyd import Signal
 
 
-class DOF256s(Device):
-    for i in range(256):
-        exec(f"x{i+1} = Cpt(Signal, value=0)")
+def get_dofs(n=2):
+    return [Signal(name=f"x{i+1}", value=0) for i in range(n)]
 
 
 class Ackley:
-    dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
+    """
+    Ackley's function in $n$ dimensions (https://en.wikipedia.org/wiki/Ackley_function)
+    """
+
+    # dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
 
     MIN_SNR = 1e1
 
@@ -21,7 +24,7 @@ class Ackley:
         self.DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(self.n_dof)]
 
     def initialize(self):
-        yield from iter([])  # do nothing
+        yield from bps.null()  # do nothing
 
     def parse_entry(self, entry):
         # get the ingredient from our dependent variables
@@ -33,23 +36,27 @@ class Ackley:
 
 
 class Himmelblau:
-    dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
+    """
+    Himmelblau's function (https://en.wikipedia.org/wiki/Himmelblau%27s_function)
+    """
+
+    # dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
 
     MIN_SNR = 1e1
 
     def __init__(self):
         self.n_dof = 2
-        self.dofs = [getattr(self.dofs_256, f"x{i+1}") for i in range(2)]
+        self.dofs = get_dofs(n=2)
         self.bounds = np.array([[0.0, 1.0] for i in range(self.n_dof)])
 
         self.DEPENDENT_COMPONENTS = [f"x{i+1}" for i in range(self.n_dof)]
 
     def initialize(self):
-        yield from iter([])  # do nothing
+        yield from bps.null()  # do nothing
 
     def parse_entry(self, entry):
         # get the ingredient from our dependent variables
-        x = 10 * (np.array([getattr(entry, f"dofs_x{i+1}") for i in range(self.n_dof)]) - 0.5)
+        x = 10 * (np.array([getattr(entry, f"x{i+1}") for i in range(self.n_dof)]) - 0.5)
 
         fitness = -1e-2 * ((x[0] ** 2 + x[1] - 11) ** 2 + (x[0] + x[1] ** 2 - 7) ** 2)
 

--- a/bloptools/experiments/tests/__init__.py
+++ b/bloptools/experiments/tests/__init__.py
@@ -12,8 +12,6 @@ class Ackley:
     Ackley's function in $n$ dimensions (https://en.wikipedia.org/wiki/Ackley_function)
     """
 
-    # dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
-
     MIN_SNR = 1e1
 
     def __init__(self, n_dof=2):
@@ -39,8 +37,6 @@ class Himmelblau:
     """
     Himmelblau's function (https://en.wikipedia.org/wiki/Himmelblau%27s_function)
     """
-
-    # dofs_256 = DOF256s(name="dofs")  # a device with 256 components (we'll subset it later)
 
     MIN_SNR = 1e1
 

--- a/bloptools/tests/test_boa.py
+++ b/bloptools/tests/test_boa.py
@@ -2,7 +2,7 @@ import numpy as np
 from sirepo_bluesky.sirepo_ophyd import create_classes
 
 from bloptools.bo import BayesianOptimizationAgent
-from bloptools.experiments.nsls2 import tes_shadow
+from bloptools.experiments.shadow import tes
 
 
 def test_tes_shadow_boa(RE, db, shadow_tes_simulation):
@@ -19,7 +19,7 @@ def test_tes_shadow_boa(RE, db, shadow_tes_simulation):
     for dof in kbs:
         dof.kind = "hinted"
 
-    boa = BayesianOptimizationAgent(dofs=kbs, dets=[w9], bounds=kb_bounds, db=db, experiment=tes_shadow)
+    boa = BayesianOptimizationAgent(dofs=kbs, dets=[w9], bounds=kb_bounds, db=db, experiment=tes)
 
     RE(boa.initialize(init_scheme="quasi-random", n_init=8))
 

--- a/bloptools/tests/test_boa.py
+++ b/bloptools/tests/test_boa.py
@@ -19,11 +19,11 @@ def test_tes_shadow_boa(RE, db, shadow_tes_simulation):
     for dof in kbs:
         dof.kind = "hinted"
 
-    boa = BayesianOptimizationAgent(dofs=kbs, dets=[w9], dof_bounds=kb_bounds, db=db, experiment=tes_shadow)
+    boa = BayesianOptimizationAgent(dofs=kbs, dets=[w9], bounds=kb_bounds, db=db, experiment=tes_shadow)
 
     RE(boa.initialize(init_scheme="quasi-random", n_init=8))
 
-    RE(boa.learn(strategy="explore", n_iter=2, n_per_iter=3))
-    RE(boa.learn(strategy="exploit", n_iter=2, n_per_iter=3))
+    RE(boa.learn(strategy="eI", n_iter=2, n_per_iter=3))
+    RE(boa.learn(strategy="eGIBBON", n_iter=2, n_per_iter=3))
 
     boa.plot_state(gridded=True)

--- a/docs/source/notebooks.rst
+++ b/docs/source/notebooks.rst
@@ -5,4 +5,4 @@ Notebooks
    :maxdepth: 2
 
    notebooks/himmelblau-2d.ipynb
-   notebooks/tes_shadow-4d.ipynb
+   notebooks/tes_shadow-2d.ipynb

--- a/docs/source/notebooks.rst
+++ b/docs/source/notebooks.rst
@@ -4,5 +4,5 @@ Notebooks
 .. toctree::
    :maxdepth: 2
 
-   notebooks/gp-optimizer-2d.ipynb
-   notebooks/gp-optimizer-4d.ipynb
+   notebooks/himmelblau-2d.ipynb
+   notebooks/tes_shadow-4d.ipynb

--- a/docs/source/notebooks/himmelblau-2d.ipynb
+++ b/docs/source/notebooks/himmelblau-2d.ipynb
@@ -1,11 +1,12 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e7b5e13a-c059-441d-8d4f-fff080d52054",
    "metadata": {},
    "source": [
-    "# Run the GP optimizer in two dimensions"
+    "# Running the optimizer with Himmelblau's function"
    ]
   },
   {
@@ -17,13 +18,12 @@
    },
    "outputs": [],
    "source": [
-    "%run -i ../../../examples/prepare_tes_shadow.py\n",
+    "%run -i ../../../examples/prepare_bluesky.py\n",
     "\n",
-    "kbs = [kbv.x_rot, kbv.offz, kbh.x_rot, kbh.offz]\n",
-    "kb_bounds = np.array([[-0.10, +0.10], [-0.50, +0.50], [-0.10, +0.10], [-0.50, +0.50]]) \n",
+    "import bloptools\n",
+    "from bloptools.experiments.tests import Himmelblau\n",
     "\n",
-    "for dof in kbs:\n",
-    "    dof.kind = \"hinted\""
+    "test_exp = Himmelblau()"
    ]
   },
   {
@@ -35,46 +35,24 @@
    },
    "outputs": [],
    "source": [
-    "from bloptools.experiments.nsls2 import tes_shadow\n",
-    "\n",
     "boa = bloptools.bo.BayesianOptimizationAgent(\n",
-    "                                             dofs=kbs, \n",
-    "                                             dets=[w9],\n",
-    "                                             dof_bounds=kb_bounds, \n",
+    "                                             dofs=test_exp.dofs, \n",
+    "                                             dets=[],\n",
+    "                                             bounds=test_exp.bounds, \n",
     "                                             db=db, \n",
-    "                                             experiment=tes_shadow\n",
+    "                                             experiment=test_exp,\n",
     "                                            )\n",
     "\n",
-    "RE(boa.initialize(init_scheme='quasi-random', n_init=16))"
+    "RE(boa.initialize(init_scheme='quasi-random', n_init=8))"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d8f2da43",
    "metadata": {},
    "source": [
-    "We initialized the GP with the \"quasi-random\" strategy, as it doesn't require any prior data. But now that we have some points to work with, we can start to call some more sophisticated learning strategies. Let's try exploring the space (\"explore\"), and then try to aim for the best possible fitness (\"exploit\")."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6b39b54",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "RE(boa.learn(strategy='explore', n_iter=4, n_per_iter=1))\n",
-    "RE(boa.learn(strategy='exploit', n_iter=4, n_per_iter=1))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aeab7a9b",
-   "metadata": {},
-   "source": [
-    "We can plot the \"state\" of the GPs, which shows their posteriors about the whole parameter space:"
+    "We initialized the GP with the \"quasi-random\" strategy, as it doesn't require any prior data. We can view the state of the optimizer:"
    ]
   },
   {
@@ -86,7 +64,51 @@
    },
    "outputs": [],
    "source": [
-    "boa.plot_state()"
+    "boa.plot_state(gridded=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "aeab7a9b",
+   "metadata": {},
+   "source": [
+    "Let's learn a bit more, using the \"GIBBON\" framework to investigate points that are likely to tell us about the optimum. Running two iterations with four points per iteration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6b39b54",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "RE(boa.learn(strategy='eGIBBON', n_iter=2, n_per_iter=4))\n",
+    "boa.plot_state(gridded=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "296d9fd2",
+   "metadata": {},
+   "source": [
+    "Now let's try the \"EI\" strategy to sample where we expect the largest improvement in the fitness:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0e74651",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "RE(boa.learn(strategy='eI', n_iter=4, n_per_iter=4))\n",
+    "boa.plot_state(gridded=True)"
    ]
   }
  ],

--- a/docs/source/notebooks/himmelblau-2d.ipynb
+++ b/docs/source/notebooks/himmelblau-2d.ipynb
@@ -128,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.16 (main, Mar  8 2023, 14:00:05) \n[GCC 11.2.0]"
   },
   "vscode": {
    "interpreter": {

--- a/docs/source/notebooks/himmelblau-2d.ipynb
+++ b/docs/source/notebooks/himmelblau-2d.ipynb
@@ -23,7 +23,7 @@
     "import bloptools\n",
     "from bloptools.experiments.tests import Himmelblau\n",
     "\n",
-    "test_exp = Himmelblau()"
+    "himmelblau = Himmelblau()"
    ]
   },
   {
@@ -36,11 +36,11 @@
    "outputs": [],
    "source": [
     "boa = bloptools.bo.BayesianOptimizationAgent(\n",
-    "                                             dofs=test_exp.dofs, \n",
+    "                                             dofs=himmelblau.dofs, \n",
     "                                             dets=[],\n",
-    "                                             bounds=test_exp.bounds, \n",
+    "                                             bounds=himmelblau.bounds, \n",
     "                                             db=db, \n",
-    "                                             experiment=test_exp,\n",
+    "                                             experiment=himmelblau,\n",
     "                                            )\n",
     "\n",
     "RE(boa.initialize(init_scheme='quasi-random', n_init=8))"

--- a/docs/source/notebooks/tes_shadow-2d.ipynb
+++ b/docs/source/notebooks/tes_shadow-2d.ipynb
@@ -37,14 +37,14 @@
    },
    "outputs": [],
    "source": [
-    "from bloptools.experiments.nsls2 import tes_shadow\n",
+    "from bloptools.experiments.shadow import tes\n",
     "\n",
     "boa = bloptools.bo.BayesianOptimizationAgent(\n",
     "                                             dofs=kbs, \n",
     "                                             dets=[w9],\n",
     "                                             bounds=kb_bounds, \n",
     "                                             db=db, \n",
-    "                                             experiment=tes_shadow\n",
+    "                                             experiment=tes\n",
     "                                            )\n",
     "\n",
     "RE(boa.initialize(init_scheme='quasi-random', n_init=8))"

--- a/docs/source/notebooks/tes_shadow-2d.ipynb
+++ b/docs/source/notebooks/tes_shadow-2d.ipynb
@@ -17,6 +17,7 @@
    },
    "outputs": [],
    "source": [
+    "%run -i ../../../examples/prepare_bluesky.py\n",
     "%run -i ../../../examples/prepare_tes_shadow.py\n",
     "\n",
     "kbs = [kbv.x_rot, kbv.offz]\n",
@@ -40,7 +41,7 @@
     "boa = bloptools.bo.BayesianOptimizationAgent(\n",
     "                                             dofs=kbs, \n",
     "                                             dets=[w9],\n",
-    "                                             dof_bounds=kb_bounds, \n",
+    "                                             dofbounds=kb_bounds, \n",
     "                                             db=db, \n",
     "                                             experiment=tes_shadow\n",
     "                                            )\n",
@@ -106,7 +107,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16 (main, Mar  8 2023, 14:00:05) \n[GCC 11.2.0]"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {

--- a/docs/source/notebooks/tes_shadow-2d.ipynb
+++ b/docs/source/notebooks/tes_shadow-2d.ipynb
@@ -1,11 +1,12 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e7b5e13a-c059-441d-8d4f-fff080d52054",
    "metadata": {},
    "source": [
-    "# Run the GP optimizer in two dimensions"
+    "# Optimize the vertical KB mirror at the TES beamline in Shadow3"
    ]
   },
   {
@@ -41,41 +42,12 @@
     "boa = bloptools.bo.BayesianOptimizationAgent(\n",
     "                                             dofs=kbs, \n",
     "                                             dets=[w9],\n",
-    "                                             dofbounds=kb_bounds, \n",
+    "                                             bounds=kb_bounds, \n",
     "                                             db=db, \n",
     "                                             experiment=tes_shadow\n",
     "                                            )\n",
     "\n",
     "RE(boa.initialize(init_scheme='quasi-random', n_init=8))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d8f2da43",
-   "metadata": {},
-   "source": [
-    "We initialized the GP with the \"quasi-random\" strategy, as it doesn't require any prior data. But now that we have some points to work with, we can start to call some more sophisticated learning strategies. Let's try exploring the space (\"explore\"), and then try to aim for the best possible fitness (\"exploit\")."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6b39b54",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "RE(boa.learn(strategy='explore', n_iter=4, n_per_iter=1))\n",
-    "RE(boa.learn(strategy='exploit', n_iter=4, n_per_iter=1))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aeab7a9b",
-   "metadata": {},
-   "source": [
-    "We can plot the \"state\" of the GPs, which shows their posteriors about the whole parameter space:"
    ]
   },
   {
@@ -87,6 +59,28 @@
    },
    "outputs": [],
    "source": [
+    "boa.plot_state(gridded=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "296d9fd2",
+   "metadata": {},
+   "source": [
+    "Maximizing the expected improvement:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6b39b54",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "RE(boa.learn(strategy='eI', n_iter=2, n_per_iter=4))\n",
     "boa.plot_state(gridded=True)"
    ]
   }
@@ -107,7 +101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.16 (main, Mar  8 2023, 14:00:05) \n[GCC 11.2.0]"
   },
   "vscode": {
    "interpreter": {

--- a/examples/prepare_bluesky.py
+++ b/examples/prepare_bluesky.py
@@ -1,0 +1,37 @@
+import datetime
+import json  # noqa F401
+
+import bluesky.plan_stubs as bps  # noqa F401
+import bluesky.plans as bp  # noqa F401
+import databroker
+import matplotlib as mpl  # noqa F401
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd  # noqa F401
+from bluesky.callbacks import best_effort
+from bluesky.run_engine import RunEngine
+from databroker import Broker
+from ophyd.utils import make_dir_tree
+from sirepo_bluesky.shadow_handler import ShadowFileHandler
+from sirepo_bluesky.sirepo_bluesky import SirepoBluesky
+from sirepo_bluesky.sirepo_ophyd import create_classes
+from sirepo_bluesky.srw_handler import SRWFileHandler
+
+import bloptools  # noqa F401
+from bloptools.bo import BayesianOptimizationAgent  # noqa F401
+
+RE = RunEngine({})
+
+bec = best_effort.BestEffortCallback()
+bec.disable_plots()
+
+RE.subscribe(bec)
+
+# MongoDB backend:
+db = Broker.named("local")  # mongodb backend
+try:
+    databroker.assets.utils.install_sentinels(db.reg.config, version=1)
+except Exception:
+    pass
+
+RE.subscribe(db.insert)

--- a/examples/prepare_tes_shadow.py
+++ b/examples/prepare_tes_shadow.py
@@ -1,40 +1,3 @@
-import datetime
-import json  # noqa F401
-
-import bluesky.plan_stubs as bps  # noqa F401
-import bluesky.plans as bp  # noqa F401
-import databroker
-import matplotlib as mpl  # noqa F401
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd  # noqa F401
-from bluesky.callbacks import best_effort
-from bluesky.run_engine import RunEngine
-from databroker import Broker
-from ophyd.utils import make_dir_tree
-from sirepo_bluesky.shadow_handler import ShadowFileHandler
-from sirepo_bluesky.sirepo_bluesky import SirepoBluesky
-from sirepo_bluesky.sirepo_ophyd import create_classes
-from sirepo_bluesky.srw_handler import SRWFileHandler
-
-import bloptools  # noqa F401
-from bloptools.bo import BayesianOptimizationAgent  # noqa F401
-
-RE = RunEngine({})
-
-bec = best_effort.BestEffortCallback()
-bec.disable_plots()
-
-RE.subscribe(bec)
-
-# MongoDB backend:
-db = Broker.named("local")  # mongodb backend
-try:
-    databroker.assets.utils.install_sentinels(db.reg.config, version=1)
-except Exception:
-    pass
-
-RE.subscribe(db.insert)
 db.reg.register_handler("srw", SRWFileHandler, overwrite=True)
 db.reg.register_handler("shadow", ShadowFileHandler, overwrite=True)
 db.reg.register_handler("SIREPO_FLYER", SRWFileHandler, overwrite=True)
@@ -44,7 +7,7 @@ plt.ion()
 root_dir = "/tmp/sirepo-bluesky-data"
 _ = make_dir_tree(datetime.datetime.now().year, base_path=root_dir)
 
-connection = SirepoBluesky("http://localhost:8000")
+connection = SirepoBluesky("http://localhost:8001")
 
 data, schema = connection.auth("shadow", "00000002")
 classes, objects = create_classes(connection.data, connection=connection)

--- a/examples/prepare_tes_shadow.py
+++ b/examples/prepare_tes_shadow.py
@@ -7,7 +7,7 @@ plt.ion()
 root_dir = "/tmp/sirepo-bluesky-data"
 _ = make_dir_tree(datetime.datetime.now().year, base_path=root_dir)
 
-connection = SirepoBluesky("http://localhost:8001")
+connection = SirepoBluesky("http://localhost:8000")
 
 data, schema = connection.auth("shadow", "00000002")
 classes, objects = create_classes(connection.data, connection=connection)


### PR DESCRIPTION
I restructured and renamed a bunch of stuff, with the philosophy that:

- The normalization of the inputs and targets happens in models.py, so that all references to "params" and "X" have units (e.g. mm for a motor) and are never normalized, which makes things a lot less confusing
- The Bayesian agent shouldn't have any torch in it, and just asks a model from models.py about the Gaussian Process. 